### PR TITLE
fix [lights]: Updated light bindings to fragment shader after delete

### DIFF
--- a/Source/DataModels/GameObject/GameObject.cpp
+++ b/Source/DataModels/GameObject/GameObject.cpp
@@ -55,13 +55,11 @@ GameObject::~GameObject()
 			case LightType::SPOT:
 				currentScene->UpdateSceneSpotLights();
 				currentScene->RenderSpotLights();
-
 				break;
 
 			case LightType::POINT:
 				currentScene->UpdateScenePointLights();
 				currentScene->RenderPointLights();
-
 				break;
 			}
 		}

--- a/Source/DataModels/GameObject/GameObject.cpp
+++ b/Source/DataModels/GameObject/GameObject.cpp
@@ -41,7 +41,34 @@ GameObject::~GameObject()
 {
 	for (Component* comp : components)
 	{
-		delete comp;
+		Scene* currentScene = App->scene->GetLoadedScene();
+
+		if (comp->GetType() == ComponentType::LIGHT)
+		{
+			ComponentLight* compLight = (ComponentLight*)comp;
+			LightType type = compLight->GetLightType();
+
+			delete comp;
+
+			switch (type)
+			{
+			case LightType::SPOT:
+				currentScene->UpdateSceneSpotLights();
+				currentScene->RenderSpotLights();
+
+				break;
+
+			case LightType::POINT:
+				currentScene->UpdateScenePointLights();
+				currentScene->RenderPointLights();
+
+				break;
+			}
+		}
+		else
+		{
+			delete comp;
+		}
 	}
 
 	components.clear();


### PR DESCRIPTION
Fixed bug where lights would still being rendered after its object parent would be removed, due to the bindings to the shader not being updated